### PR TITLE
Add task list retrieval via Java streams

### DIFF
--- a/src/main/java/todoify/chatbot/Chatbot.java
+++ b/src/main/java/todoify/chatbot/Chatbot.java
@@ -378,14 +378,13 @@ public class Chatbot extends EventEmitter<ChatMessage> {
                 builder.append("Oh nice! You have no tasks! :>");
             }
 
-            int count = 1;
-            for (Task task : this.taskManager.getTasks()) {
-                builder.append("\n");
-                builder.append(count);
-                builder.append(". ");
-                builder.append(task.toString());
-                count++;
-            }
+            this.taskManager.getTaskIndexedStream()
+                    .forEach(integerTaskPair -> {
+                        builder.append("\n");
+                        builder.append(integerTaskPair.getKey() + 1);
+                        builder.append(". ");
+                        builder.append(integerTaskPair.getValue().toString());
+                    });
 
             this.sendMessage(ChatMessage.SenderType.CHATBOT, builder.toString());
             break;
@@ -487,16 +486,20 @@ public class Chatbot extends EventEmitter<ChatMessage> {
 
             builder.append("Alright, here's the matching tasks I found:");
 
-            int count = 1;
-            for (Task task : this.taskManager.getTasks()) {
-                if (task.getTitle().toLowerCase().contains(chatCommand.getData().toLowerCase())) {
-                    builder.append("\n");
-                    builder.append(count);
-                    builder.append(". ");
-                    builder.append(task);
-                }
-                count++;
-            }
+            this.taskManager.getTaskIndexedStream()
+                    .filter(integerTaskPair -> integerTaskPair.getValue()
+                            .getTitle()
+                            .toLowerCase()
+                            .contains(
+                                    chatCommand.getData().toLowerCase()
+                            )
+                    )
+                    .forEach(integerTaskPair -> {
+                        builder.append("\n");
+                        builder.append(integerTaskPair.getKey() + 1);
+                        builder.append(". ");
+                        builder.append(integerTaskPair.getValue().toString());
+                    });
 
             builder.append("\nThat's it!");
 

--- a/src/main/java/todoify/taskmanager/TaskManager.java
+++ b/src/main/java/todoify/taskmanager/TaskManager.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -12,6 +13,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 
+import javafx.util.Pair;
 import todoify.storage.InternalPath;
 import todoify.storage.InternalStorage;
 import todoify.taskmanager.task.Deadline;
@@ -69,8 +71,21 @@ public class TaskManager {
      *
      * @return The list of tasks.
      */
-    public List<Task> getTasks() {
+    public List<Task> getTaskList() {
         return Collections.unmodifiableList(this.taskList);
+    }
+
+    /**
+     * Obtains the currently stored tasks as a stream of index-task pairs.
+     *
+     * @return The stream of tasks
+     */
+    public Stream<Pair<Integer, Task>> getTaskIndexedStream() {
+        List<Pair<Integer, Task>> indexedList = new ArrayList<>();
+        for (int i = 0; i < this.taskList.size(); i++) {
+            indexedList.add(new Pair<>(i, this.taskList.get(i)));
+        }
+        return indexedList.stream();
     }
 
     /**


### PR DESCRIPTION
This adds a new way to retrieve tasks from `TaskManager` via a new `getTaskIndexedStream` method, which allows for a stream of index-task pairs to be retrieved. 

Notably, this allows for very convenient syntax, of which the `Chatbot` class is updated to use to output tasks instead.